### PR TITLE
Framework arsenal fixes and improvements

### DIFF
--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         command: build --release --ci
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v4
       with:
         name: sia3f-${{ github.sha }}-nobin
         path: releases/sia3f_*.zip

--- a/.github/workflows/pboproject.yml
+++ b/.github/workflows/pboproject.yml
@@ -67,13 +67,13 @@ jobs:
       env:
         PYTHONUNBUFFERED: 1
     - name: Archive logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: logs
         path: temp/*.log
     - name: Archive @ace
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: '@ace3-${{ github.sha }}'
         path: z\ace\release\@ace

--- a/addons/ace/functions/fnc_initLocalArsenal.sqf
+++ b/addons/ace/functions/fnc_initLocalArsenal.sqf
@@ -70,5 +70,22 @@ private _commonItems = +_loadout + _roleItems + _groupItems;
 _commonItems = _commonItems arrayIntersect _commonItems;
 TRACE_1("local arsenal added items",_commonItems);
 
-{ [_x, _commonItems, false] call ace_arsenal_fnc_addVirtualItems } forEach _arsenals;
+{ 
+	[
+		{ (((_this select 0) call ace_arsenal_fnc_getVirtualItems) isEqualType createHashMap) && (count ((_this select 0) call ace_arsenal_fnc_getVirtualItems) > 0) },
+		{ 
+			params ["_arsenal", "_itemsToAdd"];
+			[_arsenal, _itemsToAdd, false] call ace_arsenal_fnc_addVirtualItems
+			TRACE_1("arsenal successfully updated locally with items",_itemsToAdd);
+		},
+		[_x, _commonItems],
+		1,
+		{ 
+			params ["_arsenal", "_itemsToAdd"];
+			[_arsenal, _itemsToAdd, false] call ace_arsenal_fnc_addVirtualItems;
+			["Arsenal on object failed to initialize in time for local arsenal: %1", _arsenal] call BIS_fnc_error;
+		}
+	] call CBA_fnc_waitUntilAndExecute;
+ } forEach _arsenals;
 LOG_FUNC_END;
+	

--- a/addons/ace/functions/fnc_setupGlobalArsenal.sqf
+++ b/addons/ace/functions/fnc_setupGlobalArsenal.sqf
@@ -16,7 +16,7 @@
 
 LOG_FUNC_START;
 private _arsenals = EGVAR(configuration,arsenals);
-diag_log format ["arsenals: %1",_arsenals];
+TRACE_1("arsenals",_arsenals);
 
 if !("@ace" call EFUNC(core,checkModPresence)) exitWith {};
 
@@ -62,8 +62,8 @@ if ("@KAT - Advanced Medical" call EFUNC(core,checkModPresence)) then {
 };
 
 private _customItems = (parseSimpleArray GET_CONFIG(customItems,"[]"));
-if (!(_customItems isEqualType [])) then { 
-	["Bad array of custom global arsenal items: %1",_customItems] call BIS_fnc_error;
+if (!(_customItems isEqualType "")) then { 
+	ERROR_MSG_1("Bad array of custom global arsenal items: %1",_customItems);
 } else {
 	{ _globalItems pushBackUnique _x } forEach _customItems;
 };

--- a/addons/ace/functions/fnc_setupGlobalArsenal.sqf
+++ b/addons/ace/functions/fnc_setupGlobalArsenal.sqf
@@ -16,51 +16,42 @@
 
 LOG_FUNC_START;
 private _arsenals = EGVAR(configuration,arsenals);
-TRACE_1("arsenals",_arsenals);
+diag_log format ["arsenals: %1",_arsenals];
 
-{
-	clearBackpackCargoGlobal _x;
-	clearMagazineCargoGlobal _x;
-	clearWeaponCargoGlobal _x;
-	clearItemCargoGlobal _x;
+if !("@ace" call EFUNC(core,checkModPresence)) exitWith {};
 
-	if !("@ace" call EFUNC(core,checkModPresence)) exitWith {};
+private _globalItems = [];
 
-	[_x, false] remoteExecCall ["ace_dragging_fnc_setDraggable"];
-	[_x, false] remoteExecCall ["ace_dragging_fnc_setCarryable"];
-	if ((_x call ace_arsenal_fnc_getVirtualItems) isEqualTo createHashMap) then { // make sure box isn't already an arsenal, I think init will wipe box
-		[_x, false] call ace_arsenal_fnc_initBox;	
-	};
+if (GET_CONFIG(haveBasics,true)) then {
+	// basic items
+	private _defaultList = "['ACE_fieldDressing', 'ACE_elasticBandage', 'ACE_packingBandage', 'ACE_quikclot', 'ACE_bloodIV', 'ACE_bloodIV_250', 'ACE_bloodIV_500', 'ACE_CableTie', 'ACE_Chemlight_Shield', 'ACE_EarPlugs', 'ACE_epinephrine', 'ACE_MapTools', 'ACE_morphine', 'ACE_RangeCard', 'ACE_splint', 'ACE_tourniquet', 'ACE_surgicalKit', 'ACE_salineIV', 'ACE_salineIV_250', 'ACE_salineIV_500', 'ACE_painkillers', 'ToolKit', 'ACE_artilleryTable', 'Chemlight_blue', 'Chemlight_green', 'Chemlight_red', 'Chemlight_yellow', 'ItemWatch', 'ItemCompass', 'ItemMap', 'ACE_Canteen', 'ACE_WaterBottle']";
+	_globalItems append (parseSimpleArray GET_CONFIG(basicsItems,_defaultList));
+};
 
-	private _globalItems = [];
-
-	if (GET_CONFIG(haveBasics,true)) then {
-		// basic items
-		// ToDo: allow end-user to modify data below
-		_globalItems append ["ACE_fieldDressing", "ACE_elasticBandage", "ACE_packingBandage", "ACE_quikclot", "ACE_bloodIV", "ACE_bloodIV_250", "ACE_bloodIV_500", "ACE_CableTie", "ACE_Chemlight_Shield", "ACE_EarPlugs", "ACE_epinephrine", "ACE_MapTools", "ACE_morphine", "ACE_RangeCard", "ACE_splint", "ACE_tourniquet", "ACE_surgicalKit", "ACE_salineIV", "ACE_salineIV_250", "ACE_salineIV_500", "ToolKit", "ACE_artilleryTable", "Chemlight_blue", "Chemlight_green", "Chemlight_red", "Chemlight_yellow", "ItemWatch", "ItemCompass", "ItemMap", "ACE_Canteen", "ACE_WaterBottle"];
-	};
-
-	if (GET_CONFIG(acreEnabled,true) && "@ACRE2" call EFUNC(core,checkModPresence)) then {
-		// ACRE radio items
-		private _acreRadios = ([] call acre_api_fnc_getAllRadios) select 0;
-		if (EGVAR(radio,personalRadio) != "NONE") then {
-			if (EGVAR(radio,personalRadio) in _acreRadios) then {
-				_globalItems pushBackUnique EGVAR(radio,personalRadio);
-			} else {
-				ERROR_1("Setup Global Arsenal radio, invalid radio type: %1",EGVAR(radio,personalRadio));
-			};
+if (GET_CONFIG(acreEnabled,true) && "@ACRE2" call EFUNC(core,checkModPresence)) then {
+	// ACRE radio items
+	private _acreRadios = ([] call acre_api_fnc_getAllRadios) select 0;
+	if (EGVAR(radio,personalRadio) != "NONE") then {
+		if (EGVAR(radio,personalRadio) in _acreRadios) then {
+			_globalItems pushBackUnique EGVAR(radio,personalRadio);
+		} else {
+			ERROR_1("Setup Global Arsenal radio, invalid radio type: %1",EGVAR(radio,personalRadio));
 		};
 	};
+};
 
-	if (GET_CONFIG(haveCTab,true) && "@cTab" call EFUNC(core,checkModPresence)) then {
-	// cTab items
-		_globalItems append ["ItemMicroDAGR", "ItemcTabHCam", "ItemAndroid", "ItemcTab"];
-	};
+if (GET_CONFIG(haveCTab,true) && "@cTab" call EFUNC(core,checkModPresence)) then {
+// cTab items
+	private _defaultList = "['ItemMicroDAGR', 'ItemcTabHCam', 'ItemAndroid', 'ItemcTab']";
+	_globalItems append (parseSimpleArray GET_CONFIG(cTabItems,_defaultList));
+};
 
+if ("@KAT - Advanced Medical" call EFUNC(core,checkModPresence)) then {
 	switch (GET_CONFIG(haveKATMedical,2)) do {
 		// KAT Medical items
 		case 2: {
-			_globalItems append ["kat_aatKit", "kat_accuvac", "kat_guedel", "kat_AED", "kat_X_AED", "kat_larynx", "kat_Pulseoximeter", "kat_chestSeal", "kat_Painkiller", "kat_stretcherBag", "Attachable_Helistretcher", "kat_stethoscope", "KAT_Empty_bloodIV_500", "KAT_Empty_bloodIV_250", "kat_IV_16", "kat_IO_FAST", "kat_amiodarone", "kat_atropine", "kat_lidocaine", "kat_naloxone", "kat_nitroglycerin", "kat_norepinephrine", "kat_phenylephrine", "kat_TXA", "kat_AFAK", "kat_IFAK", "kat_MFAK", "kat_BVM", "kat_pocketBVM", "kat_Carbonate", "kat_oxygenTank_150", "kat_oxygenTank_300", "kat_flumazenil"];
+			private _defaultList = "['kat_aatKit', 'kat_accuvac', 'kat_guedel', 'kat_AED', 'kat_X_AED', 'kat_larynx', 'kat_Pulseoximeter', 'kat_chestSeal', 'kat_Painkiller', 'kat_stretcherBag', 'Attachable_Helistretcher', 'kat_stethoscope', 'KAT_Empty_bloodIV_500', 'KAT_Empty_bloodIV_250', 'kat_IV_16', 'kat_IO_FAST', 'kat_amiodarone', 'kat_atropine', 'kat_lidocaine', 'kat_naloxone', 'kat_nitroglycerin', 'kat_norepinephrine', 'kat_phenylephrine', 'kat_TXA', 'kat_AFAK', 'kat_IFAK', 'kat_MFAK', 'kat_BVM', 'kat_pocketBVM', 'kat_Carbonate', 'kat_oxygenTank_150', 'kat_oxygenTank_300', 'kat_flumazenil']";
+			_globalItems append (parseSimpleArray GET_CONFIG(KATMedicalItems,_defaultList));
 		};
 
 		case 1:
@@ -68,9 +59,38 @@ TRACE_1("arsenals",_arsenals);
 			_globalItems append ["kat_guedel", "kat_larynx", "kat_chestSeal", "kat_Painkiller", "kat_IV_16", "kat_AED"];
 		};
 	};
+};
 
-	TRACE_1("items added to global arsenal",_globalItems);
-	[_x, _globalItems, true] call ace_arsenal_fnc_addVirtualItems;
+private _customItems = (parseSimpleArray GET_CONFIG(customItems,"[]"));
+if (!(_customItems isEqualType [])) then { 
+	["Bad array of custom global arsenal items: %1",_customItems] call BIS_fnc_error;
+} else {
+	{ _globalItems pushBackUnique _x } forEach _customItems;
+};
+
+{
+	clearBackpackCargoGlobal _x;
+	clearMagazineCargoGlobal _x;
+	clearWeaponCargoGlobal _x;
+	clearItemCargoGlobal _x;
+
+	[_x, false] remoteExecCall ["ace_dragging_fnc_setDraggable"];
+	[_x, false] remoteExecCall ["ace_dragging_fnc_setCarryable"];
+
+
+	private _itemsToAdd = _globalItems;
+
+	/* Not applicable due to ACE BUG 
+	private _hashVirtualItems = _x call ace_arsenal_fnc_getVirtualItems;
+	if (_hashVirtualItems isEqualTo createHashMap) then { // make sure box isn't already an arsenal, I think init will wipe box
+		[_x, false] call ace_arsenal_fnc_initBox;
+	}
+	*/
+
+	[_x, false] call ace_arsenal_fnc_initBox; // To-do: replace with code above when fixed
+
+	diag_log format ["items added to global arsenal: %1",_itemsToAdd];
+	[_x, _itemsToAdd, true] call ace_arsenal_fnc_addVirtualItems;
 } forEach _arsenals;
 
 LOG_FUNC_END;

--- a/addons/ace/functions/fnc_setupGlobalArsenal.sqf
+++ b/addons/ace/functions/fnc_setupGlobalArsenal.sqf
@@ -28,7 +28,7 @@ TRACE_1("arsenals",_arsenals);
 
 	[_x, false] remoteExecCall ["ace_dragging_fnc_setDraggable"];
 	[_x, false] remoteExecCall ["ace_dragging_fnc_setCarryable"];
-	if ((_x call ace_arsenal_fnc_getVirtualItems) isEqualTo []) then { // make sure box isn't already an arsenal, I think init will wipe box
+	if ((_x call ace_arsenal_fnc_getVirtualItems) isEqualTo createHashMap) then { // make sure box isn't already an arsenal, I think init will wipe box
 		[_x, false] call ace_arsenal_fnc_initBox;	
 	};
 

--- a/addons/ace/functions/fnc_setupGlobalArsenal.sqf
+++ b/addons/ace/functions/fnc_setupGlobalArsenal.sqf
@@ -24,7 +24,7 @@ private _globalItems = [];
 
 if (GET_CONFIG(haveBasics,true)) then {
 	// basic items
-	private _defaultList = "['ACE_fieldDressing', 'ACE_elasticBandage', 'ACE_packingBandage', 'ACE_quikclot', 'ACE_bloodIV', 'ACE_bloodIV_250', 'ACE_bloodIV_500', 'ACE_CableTie', 'ACE_Chemlight_Shield', 'ACE_EarPlugs', 'ACE_epinephrine', 'ACE_MapTools', 'ACE_morphine', 'ACE_RangeCard', 'ACE_splint', 'ACE_tourniquet', 'ACE_surgicalKit', 'ACE_salineIV', 'ACE_salineIV_250', 'ACE_salineIV_500', 'ACE_painkillers', 'ToolKit', 'ACE_artilleryTable', 'Chemlight_blue', 'Chemlight_green', 'Chemlight_red', 'Chemlight_yellow', 'ItemWatch', 'ItemCompass', 'ItemMap', 'ACE_Canteen', 'ACE_WaterBottle']";
+	private _defaultList = "['ACE_fieldDressing', 'ACE_elasticBandage', 'ACE_packingBandage', 'ACE_quikclot', 'ACE_plasmaIV', 'ACE_plasmaIV_250', 'ACE_plasmaIV_500', 'ACE_CableTie', 'ACE_Chemlight_Shield', 'ACE_EarPlugs', 'ACE_epinephrine', 'ACE_MapTools', 'ACE_morphine', 'ACE_RangeCard', 'ACE_splint', 'ACE_tourniquet', 'ACE_surgicalKit', 'ACE_salineIV', 'ACE_salineIV_250', 'ACE_salineIV_500', 'ACE_painkillers', 'ToolKit', 'ACE_artilleryTable', 'Chemlight_blue', 'Chemlight_green', 'Chemlight_red', 'Chemlight_yellow', 'ItemWatch', 'ItemCompass', 'ItemMap', 'ACE_Canteen', 'ACE_WaterBottle', 'ACE_SpareBarrel', 'acex_intelitems_notepad', 'ACE_wirecutter']";
 	_globalItems append (parseSimpleArray GET_CONFIG(basicsItems,_defaultList));
 };
 
@@ -83,11 +83,11 @@ if (!(_customItems isEqualType [])) then {
 	// wait till object is ready
 	private _localItemsToAdd = + _itemsToAdd; // use deep copy to avoid bleeding values
 	[
-		{ ((_this select 0) call ace_arsenal_fnc_getVirtualItems) isEqualType createHashMap },
+		{ (((_this select 0) call ace_arsenal_fnc_getVirtualItems) isEqualType createHashMap) && (count ((_this select 0) call ace_arsenal_fnc_getVirtualItems) > 0)},
 		{ 
 			params ["_arsenal", "_items"];
 			private _hashVirtualItems = _arsenal call ace_arsenal_fnc_getVirtualItems;
-			
+
 			// make sure box isn't already an arsenal
 			if (_hashVirtualItems isEqualTo createHashMap) then {
 				[_arsenal, _items, true] call ace_arsenal_fnc_initBox;
@@ -99,11 +99,11 @@ if (!(_customItems isEqualType [])) then {
 			diag_log format ["items added to global arsenal: %1 on object %2",_items,_arsenal];
 		},
 		[_arsenal, _localItemsToAdd],
-		1,
+		0,
 		{ 
 			params ["_arsenal", "_itemsToAdd"];
-			[_arsenal, false, true] call ace_arsenal_fnc_initBox;
-			["Arsenal on object failed to initialize: %1", _arsenal] call BIS_fnc_error;
+			[_arsenal, _itemsToAdd, true] call ace_arsenal_fnc_initBox;
+			diag_log format ["arsenal object empty or failed to fully initialize in time: %1", _arsenal];
 		}
 	] call CBA_fnc_waitUntilAndExecute;
 };

--- a/addons/configuration/FrameworkSettings/arsenalOptions.hpp
+++ b/addons/configuration/FrameworkSettings/arsenalOptions.hpp
@@ -51,5 +51,37 @@ class GVAR(arsenalOptions) {
 				};
 			};
 		};
+
+		class GVAR(basicsItems) {
+			displayName = "Basics Items Preset";
+			tooltip = "Array of classnames added to framework arsenals if 'Add Basics' is enabled";
+			property = QGVAR(basicsItems);
+			control = "EditCode";
+			defaultValue = "['ACE_fieldDressing', 'ACE_elasticBandage', 'ACE_packingBandage', 'ACE_quikclot', 'ACE_bloodIV', 'ACE_bloodIV_250', 'ACE_bloodIV_500', 'ACE_CableTie', 'ACE_Chemlight_Shield', 'ACE_EarPlugs', 'ACE_epinephrine', 'ACE_MapTools', 'ACE_morphine', 'ACE_RangeCard', 'ACE_splint', 'ACE_tourniquet', 'ACE_surgicalKit', 'ACE_salineIV', 'ACE_salineIV_250', 'ACE_salineIV_500', 'ACE_painkillers', 'ToolKit', 'ACE_artilleryTable', 'Chemlight_blue', 'Chemlight_green', 'Chemlight_red', 'Chemlight_yellow', 'ItemWatch', 'ItemCompass', 'ItemMap', 'ACE_Canteen', 'ACE_WaterBottle']";
+		};
+
+		class GVAR(cTabItems) {
+			displayName = "CTab Items Preset";
+			tooltip = "Array of classnames added to framework arsenals if 'Add CTab' is enabled";
+			property = QGVAR(cTabItems);
+			control = "EditCode";
+			defaultValue = "['ItemMicroDAGR', 'ItemcTabHCam', 'ItemAndroid', 'ItemcTab']";
+		};
+
+		class GVAR(KATMedicalItems) {
+			displayName = "KAT Medical Items Preset";
+			tooltip = "Array of classnames added to framework arsenals if 'KAT Medical Availability' is set to FULL";
+			property = QGVAR(KATMedicalItems);
+			control = "EditCode";
+			defaultValue = "['kat_aatKit', 'kat_accuvac', 'kat_guedel', 'kat_AED', 'kat_X_AED', 'kat_larynx', 'kat_Pulseoximeter', 'kat_chestSeal', 'kat_Painkiller', 'kat_stretcherBag', 'Attachable_Helistretcher', 'kat_stethoscope', 'KAT_Empty_bloodIV_500', 'KAT_Empty_bloodIV_250', 'kat_IV_16', 'kat_IO_FAST', 'kat_amiodarone', 'kat_atropine', 'kat_lidocaine', 'kat_naloxone', 'kat_nitroglycerin', 'kat_norepinephrine', 'kat_phenylephrine', 'kat_TXA', 'kat_AFAK', 'kat_IFAK', 'kat_MFAK', 'kat_BVM', 'kat_pocketBVM', 'kat_Carbonate', 'kat_oxygenTank_150', 'kat_oxygenTank_300', 'kat_flumazenil']";
+		};
+
+		class GVAR(customItems) {
+			displayName = "Custom Global Arsenal Items";
+			tooltip = "Array of classnames added to all framework arsenals. This works with the export from an Object: ACE Arsenal attributes.";
+			property = QGVAR(customItems);
+			control = "EditCode";
+			defaultValue = "[]";
+		};
 	};
 };

--- a/addons/configuration/FrameworkSettings/arsenalOptions.hpp
+++ b/addons/configuration/FrameworkSettings/arsenalOptions.hpp
@@ -57,7 +57,7 @@ class GVAR(arsenalOptions) {
 			tooltip = "Array of classnames added to framework arsenals if 'Add Basics' is enabled";
 			property = QGVAR(basicsItems);
 			control = "EditCode";
-			defaultValue = "['ACE_fieldDressing', 'ACE_elasticBandage', 'ACE_packingBandage', 'ACE_quikclot', 'ACE_bloodIV', 'ACE_bloodIV_250', 'ACE_bloodIV_500', 'ACE_CableTie', 'ACE_Chemlight_Shield', 'ACE_EarPlugs', 'ACE_epinephrine', 'ACE_MapTools', 'ACE_morphine', 'ACE_RangeCard', 'ACE_splint', 'ACE_tourniquet', 'ACE_surgicalKit', 'ACE_salineIV', 'ACE_salineIV_250', 'ACE_salineIV_500', 'ACE_painkillers', 'ToolKit', 'ACE_artilleryTable', 'Chemlight_blue', 'Chemlight_green', 'Chemlight_red', 'Chemlight_yellow', 'ItemWatch', 'ItemCompass', 'ItemMap', 'ACE_Canteen', 'ACE_WaterBottle']";
+			defaultValue = "['ACE_fieldDressing', 'ACE_elasticBandage', 'ACE_packingBandage', 'ACE_quikclot', 'ACE_plasmaIV', 'ACE_plasmaIV_250', 'ACE_plasmaIV_500', 'ACE_CableTie', 'ACE_Chemlight_Shield', 'ACE_EarPlugs', 'ACE_epinephrine', 'ACE_MapTools', 'ACE_morphine', 'ACE_RangeCard', 'ACE_splint', 'ACE_tourniquet', 'ACE_surgicalKit', 'ACE_salineIV', 'ACE_salineIV_250', 'ACE_salineIV_500', 'ACE_painkillers', 'ToolKit', 'ACE_artilleryTable', 'Chemlight_blue', 'Chemlight_green', 'Chemlight_red', 'Chemlight_yellow', 'ItemWatch', 'ItemCompass', 'ItemMap', 'ACE_Canteen', 'ACE_WaterBottle', 'ACE_SpareBarrel', 'acex_intelitems_notepad', 'ACE_wirecutter']";
 		};
 
 		class GVAR(cTabItems) {

--- a/addons/configuration/README.md
+++ b/addons/configuration/README.md
@@ -21,6 +21,10 @@ This will define all of the variables that can be used with ``GET_CONFIG(var,def
 |haveBasics|Add Basics|If checked, basic items such as compasses, maps, and first aid supplies will be added.|Boolean|True|
 |haveCTab|Add CTab|If checked and if CTab is loaded in the mission, CTab items such as the helmet camera and rugged tablet will be added.|Boolean|True|
 |haveKATMedical|KAT Medical Availability|Options are "FULL" (2), "LIMITED" (1), or "NONE" (0).  Full will add all KAT items, Limited will add some KAT items (e.g, guedel tube, chest Seal, painkillers, etc.), and None will add no KAT items.|Integer<0, 1, 2>|2|
+|customItems|Custom Global Arsenal Items|Array of classnames added to all framework arsenals|
+|basicsItems|Basics Preset|Array of classnames added to framework arsenals if 'Add Basics' is enabled.
+|cTabItems|CTab Items Preset|Array of classnames added to framework arsenals if 'Add CTab' is enabled.
+|KATMedicalItems|KAT Medical Items Preset|Array of classnames added to framework arsenals if 'KAT Medical Availability' is set to FULL.
 |**ACRE Radio Options**|
 |acreEnabled|ACRE Enabled|To be changed to "Radio Enabled".  If checked and if ACRE is loaded in the mission, radio ACE Options and arsenal items will be added.|Boolean|True|
 |personalRadio|Personal Radio|Option of what the personal radio is (added to all units).  Options are "AN/PRC-343" (0) or "Beofeng 888S" (1).|Integer<0, 1>|0|

--- a/addons/configuration/README.md
+++ b/addons/configuration/README.md
@@ -22,9 +22,9 @@ This will define all of the variables that can be used with ``GET_CONFIG(var,def
 |haveCTab|Add CTab|If checked and if CTab is loaded in the mission, CTab items such as the helmet camera and rugged tablet will be added.|Boolean|True|
 |haveKATMedical|KAT Medical Availability|Options are "FULL" (2), "LIMITED" (1), or "NONE" (0).  Full will add all KAT items, Limited will add some KAT items (e.g, guedel tube, chest Seal, painkillers, etc.), and None will add no KAT items.|Integer<0, 1, 2>|2|
 |customItems|Custom Global Arsenal Items|Array of classnames added to all framework arsenals|
-|basicsItems|Basics Preset|Array of classnames added to framework arsenals if 'Add Basics' is enabled.
-|cTabItems|CTab Items Preset|Array of classnames added to framework arsenals if 'Add CTab' is enabled.
-|KATMedicalItems|KAT Medical Items Preset|Array of classnames added to framework arsenals if 'KAT Medical Availability' is set to FULL.
+|basicsItems|Basics Preset|Array of classnames added to framework arsenals if 'Add Basics' is enabled|
+|cTabItems|CTab Items Preset|Array of classnames added to framework arsenals if 'Add CTab' is enabled|
+|KATMedicalItems|KAT Medical Items Preset|Array of classnames added to framework arsenals if 'KAT Medical Availability' is set to FULL|
 |**ACRE Radio Options**|
 |acreEnabled|ACRE Enabled|To be changed to "Radio Enabled".  If checked and if ACRE is loaded in the mission, radio ACE Options and arsenal items will be added.|Boolean|True|
 |personalRadio|Personal Radio|Option of what the personal radio is (added to all units).  Options are "AN/PRC-343" (0) or "Beofeng 888S" (1).|Integer<0, 1>|0|


### PR DESCRIPTION
This pull request will:
resolve #95
resolve #53 

- fix issue with arsenal not being applied to an enabled object unless they also had an item enabled in their ACE Arsenal object attributes. (related to #95)
- Add input field in Framework Arsenal settings for additional global arsenal items
- Tweak Basic Items preset to include more basic ace items (e.g. spare barrel, notepad, plasma)
- Tweal KAT Full preset to include recent KAT items
- ~~optimize setupGlobalArsenal function~~ idk at this point