### PR TITLE
add check for whether framework has been initialized

### DIFF
--- a/addons/ace/functions/fnc_updateAutosave.sqf
+++ b/addons/ace/functions/fnc_updateAutosave.sqf
@@ -16,7 +16,7 @@
 
 LOG_FUNC_START;
 
-if (GET_CONFIG(enableManageKit,false)) then {
+if ((GET_CONFIG(enableManageKit,false)) && (GET_CONFIG(frameworkInit,false))) then {
 	if (_this) then {
 		GVAR(arsenalClosedEH) = ["ace_arsenal_displayClosed", {
 			if ((player getVariable [QEGVAR(core,savedLoadout), []]) isEqualTo []) then {


### PR DESCRIPTION
This pull request will prevent the loadout autosave EH from being applied on scenarios where the framework has not been initialized

Resolves: #103